### PR TITLE
add notice about change in lesson ownership on adoption

### DIFF
--- a/policy/lesson-adoption.md
+++ b/policy/lesson-adoption.md
@@ -9,7 +9,7 @@ author:
 
 This document describes the process for proposing and adopting new Library Carpentry lessons into the curriculum. We will adopt [The Carpentries Lab](https://carpentries-lab.org/) as the primary way for adding new lessons to the Library Carpentry lesson collection. There can be exceptions to accepting lessons outside of this process at the discretion of the CAC. 
 
-### Assumed Prior Work
+## Assumed Prior Work
 
 * Lesson authors will have designed their lesson with the [Library Carpentry audiences](https://librarycarpentry.org/audience/) in focus, e.g. library and information-related communities. 
 * Lesson authors will follow the lesson development process as outlined in [the Curriculum Development Handbook](https://cdh.carpentries.org) (see the [Collaborative Lesson Development Training lesson for guidance](https://carpentries.github.io/lesson-development-training/)). 
@@ -23,4 +23,8 @@ This document describes the process for proposing and adopting new Library Carpe
 4. Once the lesson has been taught and maintainers have responded to feedback, the maintainers will request a review in [Carpentries Lab](https://carpentries-lab.org/). 
 5. Members of LC-CAC will serve an editorial role in the Lab review process, going through the initial Lab checklist and helping to find suitable peer reviewers for the lesson. 
 6. When the review process has been completed and the lesson is approved for full adoption, the lesson repository will be transferred into the Library Carpentry organisation on GitHub. Lesson maintainers will be invited to join the next round of Maintainer Onboarding, to reflect the lesson's new status as an official lesson within Library Carpentry.
+
+## Change of Lesson Ownership After Adoption
+
+It is important to note that adoption of a lesson from The Carpentries Incubator, where lessons are owned by the community members who have been developing them, into Library Carpentry will result in the lesson becoming owned by Library Carpentry. The styling and layout of the lesson site will be updated to reflect its new status as an official Library Carpentry lesson, and the copyright notice, license, etc will be also be adjusted. If you have any questions or concerns about this implication of lesson adoption, please [contact Toby Hodges](tobyhodges@carpentries.org), who will be happy to try to address them.
 


### PR DESCRIPTION
As discussed at today's CAC meeting, this adds a note to lesson authors about the implications of a lesson being transferred from the Incubator into the Library Carpentry lesson collection.