### PR TITLE
Create lc-overview-decommission-notes

### DIFF
--- a/notes/lc-overview-decommission-notes
+++ b/notes/lc-overview-decommission-notes
@@ -1,0 +1,26 @@
+*2023-10-12*
+
+Per multiple discussions and a decision by the LC-CAC on 2023-09-21, the LC-Overview lesson will be decommissioned and removed from from the LC Core curriculum. 
+
+Who will do the work:
+Elizabeth "Lisa" McAulay (github user name: emcaulay)
+Tim Dennis (github user name:)
+
+*2023-10-12*
+
+Lisa and Tim  meet for first time to review next actions. 
+
+From the notes from CAC meeting (taken from etherpad)
+To DO:
+
+1. "Add a callout box in the Index.md file - the best we can do right now. "
+
+Lisa can't remember the context of the discussion and so can't remember what the purpose of the callout box is. She thinks it was to alert current users of the LC-Overview lesson that it will be decommissioned.
+
+2. SLACK announcements to 
+2a. Libraries channel, slack (#libraries) 
+2b. instructors channels (#instructors,
+
+3. Email announcements via topicbox
+3a. (https://carpentries.topicbox.com/groups/discuss-library-carpentry),  
+3b. https://carpentries.topicbox.com/groups/instructors), 


### PR DESCRIPTION
Per 2023-09-21 LC-CAC decision, I am working to decommission the LC-Overview lesson. 

I need a community-sponsored place to keep track of notes and actions so that I can share notes with people and leave notes that I can refer back to.

This repo and this folder seem like a good location for that.
